### PR TITLE
chore: MongoDB 환경변수 기반 연결 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### 환경변수 ###
+.env

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.application.name=memekly
+
+spring.data.mongodb.uri=${MONGO_URI}
+spring.data.mongodb.database=${MONGO_DB}


### PR DESCRIPTION
## 📌 작업 내용
- MongoDB Atlas 연결을 위한 환경변수 기반 설정 추가
- `application.properties`에서 `${MONGO_URI}` 등으로 참조하도록 구성
- MongoDB Java Driver 자동 의존성 추가 (`spring-boot-starter-data-mongodb`)

## 🧪 테스트 내역
- IntelliJ Database 탭에서 MongoDB 연결 테스트 완료 (성공)
- Spring Boot 실행 후 URI 경로 정상 로드 확인
<img width="1563" alt="image" src="https://github.com/user-attachments/assets/ef38944e-f945-4846-a192-63c42d202bf3" />

## 📝 비고
- `.env` 파일은 로컬에서 개별 관리
- `.gitignore`에 `.env` 추가되어 있음
